### PR TITLE
Improved Compatiblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ or
 ```
 ln -s $(pwd)/dmenu_raycast ~/.local/bin
 ```
+
+It may also be advisable to rename, symlink, or alias `dmenu_raycast` to simply `dmenu` in order to ensure compatibility with existing dmenu scripts.

--- a/dmenu_raycast
+++ b/dmenu_raycast
@@ -21,7 +21,7 @@ If no option was chosen, the program will exit with the return code set to 1."""
 )
 
 parser.add_argument("-p", "--prompt", help="search bar placeholder text")
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 
 server = socket.socket()


### PR DESCRIPTION
dmenu has several other flags which aren't useful for Raycast such as `-l` for how many lines of options to show, `-i` for ignoring case in the fuzzy matching, etc. This patch improves compatibility with existing dmenu scripts by adjusting the script so that it doesn't choke when those args are passed as well